### PR TITLE
Rename "transcription" languages to "speaker" languages to match CaptionKit UI

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -53,7 +53,7 @@ export function UpdateActions(self: ModuleInstance): void {
 		},
 
 		language_select: {
-			name: 'Set transcription language',
+			name: 'Set speaker language',
 			options: [
 				{
 					id: 'language',

--- a/src/feedbacks.ts
+++ b/src/feedbacks.ts
@@ -13,8 +13,8 @@ export function UpdateFeedbacks(self: ModuleInstance): void {
 			options: [],
 			callback: () => !!self.broadcastLive,
 		},
-		transcription_language_live: {
-			name: 'Transcription language is live',
+		speaker_language_live: {
+			name: 'Speaker language is live',
 			type: 'boolean',
 			defaultStyle: {
 				bgcolor: combineRgb(204, 0, 0),

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -108,7 +108,7 @@ export function UpdatePresets(self: ModuleInstance): void {
 	for (const language of self.inputLanguages) {
 		const preset: CompanionPresetDefinition = {
 			type: 'button',
-			category: 'Transcription Languages',
+			category: 'Speaker Languages',
 			name: language.label,
 			style: {
 				size: 12,
@@ -131,7 +131,7 @@ export function UpdatePresets(self: ModuleInstance): void {
 			],
 			feedbacks: [
 				{
-					feedbackId: 'transcription_language_live',
+					feedbackId: 'speaker_language_live',
 					options: {
 						language: language.id,
 					},


### PR DESCRIPTION
Hope this makes sense - there are three competing sets of terminology:

* speaker/translation languages (in the UI)
* transcription/translation languages (in the API docs)
* input/output languages (in the API endpoint to retrieve available languages)

With "transcription" and "translation" looking quite similar in English, I prefer "Speaker" over "Transcription" for clarity.